### PR TITLE
fix package.json formatting

### DIFF
--- a/viz-send-image-app/package.json
+++ b/viz-send-image-app/package.json
@@ -11,7 +11,7 @@
     "express": "^4.14.0",
     "multer": "^1.2.0",
     "cloudant": "latest",
-    "path": "latest",
+    "path": "latest"
   },
   "author": {
     "name": "hovig ohannessian"


### PR DESCRIPTION
Address problem introduced with https://github.com/IBM/image-analysis-iot-alert/pull/4

npm install fails with `npm ERR! code EJSONPARSE` due to misformat in `package.json`